### PR TITLE
Added support for MacOS (Darwin)

### DIFF
--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+import platform
+if platform.system() == 'Darwin':
+    import sh
+
 from dataclasses import dataclass, field
 import subprocess
 from typing import Any, List, Mapping, Optional
@@ -37,10 +41,16 @@ class Options:
         return Options(**fields_values)
 
 def get_current_program(pid: int, shells: List[str]) -> Optional[str]:
-    try:
-        program = subprocess.check_output(['ps', '-f', '--no-headers', '--ppid', str(pid)])
-    except subprocess.CalledProcessError:
-        return None
+    if platform.system() == 'Darwin':
+        try:
+            program = sh.grep(sh.ps('-o ppid,pid,user,cpu,stime,tty,time,command', _tty_size=(20, 500),), f"^{pid}").stdout
+        except sh.ErrorReturnCode_1:
+            return None
+    else:
+        try:
+            program = subprocess.check_output(['ps', '-f', '--no-headers', '--ppid', str(pid)])
+        except subprocess.CalledProcessError:
+            return None
 
     program = program.split()[7:]
 


### PR DESCRIPTION
The Darwin (MacOS) ps is not compatible with the params you are using, so I made a workaround splitting the task up in ps + grep. However
subprocess.check_output() does not support piped commands directly, and using shell=True is not recommended, and chaining two Popen adds code complexity, so I opted to use the available sh packet, which inherently supports chaining commands.
If you totally object to another external package, I still have my chained Popen code lying around, so I could add that approach in a separate PR. 

To ensure my change has no impact on the rest of this tool, I made my best effort to emulate the GNU ps output.

I rearranged the order of the first 3 columns of ps output to put ppid first, so that grep ^pid could identify relevant lines.
Since you cut off the first 6 items it does not have any impact at this point, I just thought I should mention it so that if it leads to confusion later there is a note about the reason for this change.

The very wide tty I have given the ps command is to ensure the line isn't cut off at this point, and let the  @tmux_window_name_max_name_len
setting make the decision when the window name is assigned.

The default tty width for sh commands is 80, and from that the first 6 output columns used by rename_session_windows.py, eats up 53, only leaving 27 spaces of actual content.

As I removed my use_tilde new feature to only add Darwin support in this PR, I unintentionally also removed one change that should be in this PR. This line should be added to tmux_window_name.tmux to ensure auto-installation of the dependency sh

[ "$(uname -s)" = "Darwin" ] && python -m pip install sh --user