### PR TITLE
Display warning if libtmux is not installed

### DIFF
--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -2,7 +2,10 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-python3 -m pip install libtmux --user
+if [ "$(pip3 list | grep libtmux)" = "" ]; then
+    tmux display "ERROR: tmux-window-name - Python dependency libtmux not found (Check the README)"
+    exit 0
+fi
 
 tmux set -g automatic-rename off
 tmux set-hook -g 'session-window-changed[8921]' "run-shell "$CURRENT_DIR/scripts/rename_session_windows.py""


### PR DESCRIPTION
The current approach, blindly installing a package is error-prone. Especially combined with the lack of information if the install fails, causing needless confusion why things are not working as expected.
The only way to see the error is to run `./tmux_window_name.tmux` in a terminal. Which might not be an obvious thing to be tried by less techy users.

Secondly, assuming a pip install will succeed is prone to failure in the first place. People working a lot with virtualenvs will likely have set

```
export PIP_REQUIRE_VIRTUALENV=true
```

To ensure nothing gets unintentionally installed in the global env.

This prevents a global pip install unless you manually request it:

```
PIP_REQUIRE_VIRTUALENV=false pip3 install libtmux
```

I think a better approach is to just check if it is available, and if not, display a warning, making the user aware that this needs to be resolved. If it is listed as a dependency in the README, that should be all that is needed.