### PR TITLE
Leverage user options and hooks to avoid overriding user-defined window names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# Better Window names for tmux
+# Better Window Names for tmux
 
 A plugin to name your tmux windows smartly, like IDE's.
 
 ![Tmux Window Name Screenshot](screenshots/example.png)
+
+## Index
+* [Use case](#use-case)
+* [Usage](#usage)
+* [How it works](#how-it-works)
+* [Installation](#installation)
+* [Configuration Options](#configuration-options)
 
 ## Dependencies
 
@@ -11,17 +18,16 @@ A plugin to name your tmux windows smartly, like IDE's.
 * pip
 * [libtmux](https://github.com/tmux-python/libtmux)
 
-## Usage
+## Use case
 
 If you are using tmux as your main multiplexer you probably found yourself with 5+ windows per session with indexed names but no information about whats going on in the windows.
 
 You tried to configure `automatic-rename` and `automatic-rename-format` but you found yourself pretty limited.
 
-This plugin comes to solve those issues to name your windows inspired by IDE tablines.
-
+This plugin comes to solve those issues to name your windows inspired by IDE tablines.\
 It makes sure to show you the shortest path possible!
 
-### Examples
+#### Examples
 This session:
 ```
 1. ~/workspace/my_project
@@ -56,8 +62,20 @@ Will display:
 
 For more scenarios you check out the [tests](tests/test_exclusive_paths.py).
 
+## Usage
+[Install](#installation) the plugin and let it name your windows :)
+
+You can `tmux rename-window` manually to set your own window names, to re-enable automatic renames set run `tmux rename-window ""`
+
+Make sure your configuration/other plugins doesn't turn on `automatic-rename` and doesn't rename your windows.
+
+#### Hooks Used
+Make sure the hooks that used aren't overridden.
+* @resurrect-hook-pre-restore-all
+* @resurrect-hook-post-restore-all
+
 ## Known Issues
-* Overrides `tmux rename-window` of the user (if you have some idea how to detect it please let me know).
+* [tmux-resurrect doesn't preserve manual windows names](https://github.com/ofirgall/tmux-window-name/issues/12)
 
 ---
 

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -44,7 +44,8 @@ def get_window_option(server: libtmux.Server, window_id: Optional[str], option:s
 
 
 def enable_user_rename_hook(server: libtmux.Server):
-    server.cmd('set-hook', '-g', f'after-rename-window[{HOOK_INDEX}]', f'if-shell "[ #{{n:window_name}} -gt 0 ]" "set -uw @tmux_window_name_enabled" "set -w @tmux_window_name_enabled 1; run-shell "{__file__}"')
+    current_file = Path(__file__).absolute()
+    server.cmd('set-hook', '-g', f'after-rename-window[{HOOK_INDEX}]', f'if-shell "[ #{{n:window_name}} -gt 0 ]" "set -uw @tmux_window_name_enabled" "set -w @tmux_window_name_enabled 1; run-shell "{current_file}"')
 
 
 def disable_user_rename_hook(server: libtmux.Server):
@@ -207,10 +208,16 @@ def main():
 
     parser = ArgumentParser('Renames tmux session windows')
     parser.add_argument('--print_programs', action='store_true', help='Prints full name of the programs in the session')
+    parser.add_argument('--enable_rename_hook', action='store_true', help='Enables rename hook, for internal use')
+    parser.add_argument('--disable_rename_hook', action='store_true', help='Enables rename hook, for internal use')
 
     args = parser.parse_args()
     if args.print_programs:
         print_programs(server)
+    elif args.enable_rename_hook:
+        enable_user_rename_hook(server)
+    elif args.disable_rename_hook:
+        disable_user_rename_hook(server)
     else:
         rename_windows(server)
 

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -30,7 +30,7 @@ def set_option(server: libtmux.Server, option: str, val: str):
     server.cmd('set-option', '-g', f'{OPTIONS_PREFIX}{option}', val)
 
 
-def get_window_option(server: libtmux.Server, window_id: Optional[str], option:str, default:Any) -> Any:
+def get_window_option(server: libtmux.Server, window_id: Optional[str], option: str, default: Any) -> Any:
     arguments = ['show-option', '-wqv']
     if window_id is not None:
         arguments.append('-t')
@@ -44,8 +44,18 @@ def get_window_option(server: libtmux.Server, window_id: Optional[str], option:s
 
 
 def enable_user_rename_hook(server: libtmux.Server):
+    """
+    The hook:
+        if window has name:
+            set @tmux_window_name_enabled to 1
+        else:
+            set @tmux_window_name_enabled to 0
+
+    @tmux_window_name_enabled (window option):
+        Indicator if we should rename the window or not
+    """
     current_file = Path(__file__).absolute()
-    server.cmd('set-hook', '-g', f'after-rename-window[{HOOK_INDEX}]', f'if-shell "[ #{{n:window_name}} -gt 0 ]" "set -uw @tmux_window_name_enabled" "set -w @tmux_window_name_enabled 1; run-shell "{current_file}"')
+    server.cmd('set-hook', '-g', f'after-rename-window[{HOOK_INDEX}]', f'if-shell "[ #{{n:window_name}} -gt 0 ]" "set -w @tmux_window_name_enabled 0" "set -w @tmux_window_name_enabled 1; run-shell "{current_file}"')
 
 
 def disable_user_rename_hook(server: libtmux.Server):
@@ -157,7 +167,7 @@ def rename_windows(server: libtmux.Server):
 
 
         for pane in panes_with_programs:
-            enabled_in_window = get_window_option(server, pane.info['window_id'], 'enabled', 0)
+            enabled_in_window = get_window_option(server, pane.info['window_id'], 'enabled', 1)
             if not enabled_in_window:
                 continue
 
@@ -173,7 +183,7 @@ def rename_windows(server: libtmux.Server):
         exclusive_paths = get_exclusive_paths(panes_with_dir)
 
         for p, display_path in exclusive_paths:
-            enabled_in_window = get_window_option(server, p.info['window_id'], 'enabled', 0)
+            enabled_in_window = get_window_option(server, p.info['window_id'], 'enabled', 1)
             if not enabled_in_window:
                 continue
 

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -43,7 +43,7 @@ def get_window_option(server: libtmux.Server, window_id: Optional[str], option:s
 
 
 def enable_user_rename_hook(server: libtmux.Server):
-    server.cmd('set-hook', '-g', f'after-rename-window[{HOOK_INDEX}]', f'set -uw {OPTIONS_PREFIX}enabled')
+    server.cmd('set-hook', '-g', f'after-rename-window[{HOOK_INDEX}]', f'if-shell "[ #{{n:window_name}} -gt 0 ]" "set -uw @tmux_window_name_enabled" "set -w @tmux_window_name_enabled 1; run-shell "{__file__}"')
 
 
 def disable_user_rename_hook(server: libtmux.Server):

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -159,6 +159,7 @@ def rename_windows(server: libtmux.Server):
             enabled_in_window = get_window_option(server, pane.info['window_id'], 'enabled', 0)
             if not enabled_in_window:
                 continue
+
             program_name = get_program_if_dir(pane.program, options.dir_programs)
             if program_name is not None:
                 pane.program = program_name
@@ -174,6 +175,7 @@ def rename_windows(server: libtmux.Server):
             enabled_in_window = get_window_option(server, p.info['window_id'], 'enabled', 0)
             if not enabled_in_window:
                 continue
+
             if p.program is not None:
                 p.program = substitute_program_name(p.program, options.substitute_sets)
                 display_path = f'{p.program}:{display_path}'

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -10,6 +10,5 @@ fi
 
 tmux set -g automatic-rename off
 tmux set-hook -g 'after-select-window[8921]' "run-shell ""$CURRENT_DIR""/scripts/rename_session_windows.py"
-tmux set-hook -g 'after-new-window[8921]' 'set -w @tmux_window_name_enabled 1'
 
 "$CURRENT_DIR"/scripts/rename_session_windows.py --enable_rename_hook

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -10,5 +10,5 @@ fi
 
 tmux set -g automatic-rename off
 tmux set-hook -g 'after-select-window[8921]' "run-shell "$CURRENT_DIR/scripts/rename_session_windows.py""
-tmux set-hook -g 'after-rename-window[8921]' 'set -uw @tmux_window_name_enabled'
+tmux set-hook -g 'after-rename-window[8921]' 'if-shell "[ #{n:window_name} -gt 0 ]" "set -uw @tmux_window_name_enabled" "set -w @tmux_window_name_enabled 1; run-shell \"'"$CURRENT_DIR/scripts/rename_session_windows.py"'\""'
 tmux set-hook -g 'after-new-window[8921]' 'set -w @tmux_window_name_enabled 1'

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -10,3 +10,5 @@ fi
 
 tmux set -g automatic-rename off
 tmux set-hook -g 'after-select-window[8921]' "run-shell "$CURRENT_DIR/scripts/rename_session_windows.py""
+tmux set-hook -g 'after-rename-window[8921]' 'set -uw @tmux_window_name_enabled'
+tmux set-hook -g 'after-new-window[8921]' 'set -w @tmux_window_name_enabled 1'

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -9,6 +9,6 @@ if ! echo "$pip_list" | grep libtmux -q; then
 fi
 
 tmux set -g automatic-rename off
-tmux set-hook -g 'after-select-window[8921]' "run-shell "$CURRENT_DIR/scripts/rename_session_windows.py""
+tmux set-hook -g 'after-select-window[8921]' "run-shell ""$CURRENT_DIR""/scripts/rename_session_windows.py"
 tmux set-hook -g 'after-rename-window[8921]' 'if-shell "[ #{n:window_name} -gt 0 ]" "set -uw @tmux_window_name_enabled" "set -w @tmux_window_name_enabled 1; run-shell \"'"$CURRENT_DIR/scripts/rename_session_windows.py"'\""'
 tmux set-hook -g 'after-new-window[8921]' 'set -w @tmux_window_name_enabled 1'

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -9,7 +9,7 @@ if ! echo "$pip_list" | grep libtmux -q; then
 fi
 
 tmux set -g automatic-rename off
-tmux set-hook -g 'after-select-window[8921]' "run-shell ""$CURRENT_DIR""/scripts/rename_session_windows.py"
+tmux set-hook -g 'after-select-window[8921]' "run-shell -b ""$CURRENT_DIR""/scripts/rename_session_windows.py"
 
 ############################################################################################
 ### Hacks for preserving users custom window names, read more at enable_user_rename_hook ###

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -10,5 +10,6 @@ fi
 
 tmux set -g automatic-rename off
 tmux set-hook -g 'after-select-window[8921]' "run-shell ""$CURRENT_DIR""/scripts/rename_session_windows.py"
-tmux set-hook -g 'after-rename-window[8921]' 'if-shell "[ #{n:window_name} -gt 0 ]" "set -uw @tmux_window_name_enabled" "set -w @tmux_window_name_enabled 1; run-shell \"'"$CURRENT_DIR/scripts/rename_session_windows.py"'\""'
 tmux set-hook -g 'after-new-window[8921]' 'set -w @tmux_window_name_enabled 1'
+
+"$CURRENT_DIR"/scripts/rename_session_windows.py --enable_rename_hook

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -11,4 +11,12 @@ fi
 tmux set -g automatic-rename off
 tmux set-hook -g 'after-select-window[8921]' "run-shell ""$CURRENT_DIR""/scripts/rename_session_windows.py"
 
+############################################################################################
+### Hacks for preserving users custom window names, read more at enable_user_rename_hook ###
+############################################################################################
+
 "$CURRENT_DIR"/scripts/rename_session_windows.py --enable_rename_hook
+
+# Disabling rename hooks when tmux-ressurect restores the sessions
+tmux set -g @resurrect-hook-pre-restore-all ""$CURRENT_DIR"/scripts/rename_session_windows.py --disable_rename_hook"
+tmux set -g @resurrect-hook-post-restore-all ""$CURRENT_DIR"/scripts/rename_session_windows.py --enable_rename_hook"


### PR DESCRIPTION
commit 92e5d358c8149824ec1326bca3ee3549d5d1a2eb

    Track user-defined names with Tmux user option
    
    A Tmux user option @tmux_window_name_enabled (by default 1) is added,
    and an after-rename-window hook clears it in current window.
    
    So when a user renames a window, the option is cleared. When we rename
    windows, we temporarily remove the hook and add it back when we finish.

commit e6524d768516d270be2ef232b0944ce708416898

    Implement a guard to avoid racing
    
    Otherwise when our process is running, another process may be about to
    finish and adds the hook back, and later window renaming in our process
    will trigger the hook and remove @tmux_window_name_enabled
    unintentionally.

commit ca10769a2c452698e42176833c4a29e8187dc61d

    Add binding <prefix>" to enable tmux-window-name

commit 2c69b6a832f0e0c750055dfa524603dd9d0e4a35

    Fix quoting to avoid word splitting
    
    The second argument actually consisted of three strings:
    
    - "run-shell"
    - $CURRENT_DIR/scripts/rename_session_windows.py
    - ""

---

Second try :P
