### PR TITLE
Add 'fish' to the list of shells by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ _**Note**_: All options are evaluated with [eval](https://docs.python.org/3/libr
 Shell programs, will show dir instead of the program
 
 ```tmux.conf
-set -g @tmux_window_name_shells "['zsh', 'bash', 'sh']"
+set -g @tmux_window_name_shells "['bash', 'fish', 'sh', 'zsh']"
 ```
 
 ### `@tmux_window_name_dir_programs`

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -113,7 +113,7 @@ def tmux_guard(server: Server) -> Iterator[bool]:
 
 @dataclass
 class Options:
-    shells: List[str] = field(default_factory=lambda: ['zsh', 'bash', 'sh'])
+    shells: List[str] = field(default_factory=lambda: ['bash', 'fish', 'sh', 'zsh'])
     dir_programs: List[str] = field(default_factory=lambda: ['nvim', 'vim', 'vi', 'git'])
     ignored_programs: List[str] = field(default_factory=lambda: [])
     max_name_len: int = 20


### PR DESCRIPTION
Fish is a relatively popular shell, it seems nice to just have it included in the list of shells by default.

Also, alphabetically sort the list of shells.