### PR TITLE
Fix SyntaxWarning for unescaped backslashes due to Python upgrade

### DIFF
--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -122,7 +122,7 @@ class Options:
     ignored_programs: List[str] = field(default_factory=lambda: [])
     max_name_len: int = 20
     use_tilde: bool = False
-    substitute_sets: List[Tuple] = field(default_factory=lambda: [('.+ipython([32])', r'ipython\g<1>'), USR_BIN_REMOVER, ('(bash) (.+)/(.+[ $])(.+)', '\g<3>\g<4>')])
+    substitute_sets: List[Tuple] = field(default_factory=lambda: [('.+ipython([32])', r'ipython\\g<1>'), USR_BIN_REMOVER, ('(bash)(.+)/(.+[ $])(.+)', '\\g<3>\\g<4>')])
     dir_substitute_sets: List[Tuple] = field(default_factory=lambda: [])
     log_level: str = 'WARNING'
 

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -122,7 +122,7 @@ class Options:
     ignored_programs: List[str] = field(default_factory=lambda: [])
     max_name_len: int = 20
     use_tilde: bool = False
-    substitute_sets: List[Tuple] = field(default_factory=lambda: [('.+ipython([32])', r'ipython\\g<1>'), USR_BIN_REMOVER, ('(bash)(.+)/(.+[ $])(.+)', '\\g<3>\\g<4>')])
+    substitute_sets: List[Tuple] = field(default_factory=lambda: [('.+ipython([32])', r'ipython\\g<1>'), USR_BIN_REMOVER, ('(bash) (.+)/(.+[ $])(.+)', '\\g<3>\\g<4>')])
     dir_substitute_sets: List[Tuple] = field(default_factory=lambda: [])
     log_level: str = 'WARNING'
 


### PR DESCRIPTION
The warning appeared after upgrading to a newer version of [python](https://www.python.org/downloads/release/python-3120/).

Fix it by changing  `\` to `\\` in the affected string.

