### PR TITLE
Fix issue for ignored program with no params

### DIFF
--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -168,7 +168,7 @@ def get_current_program(running_programs: List[bytes], pane: TmuxPane, options: 
                 continue
 
             if program_name_stripped in options.ignored_programs:
-                logging.debug(f'skipping {program[1]}, its ignored')
+                logging.debug(f'skipping {program_name_stripped}, its ignored')
                 continue
 
             # Ignore shells


### PR DESCRIPTION
Ignored program may have no params. In my case I added `nvim` to `@tmux_window_name_ignored_programs`
But then if I had a process that was `nvim` (and not `nvim file/path.py`) the script would error.

This uses the parsed program name in the debug.