### PR TITLE
Add an option to show nerd font icons for well known apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,41 @@ set -g @tmux_window_name_dir_substitute_sets "[('tmux-(.+)', '\\g<1>')]"
 set -g @tmux_window_name_dir_substitute_sets "[]"
 ```
 
+### `@tmux_window_name_icon_style`
+
+Configure how icons are displayed in window names. \
+Available styles:
+- `name`: Show only program name (default)
+- `icon`: Show only icon
+- `name+icon`: Show both icon and program name
+
+```tmux.conf
+# Show only icons
+set -g @tmux_window_name_icon_style "'icon'"
+
+# Show icons with program names
+set -g @tmux_window_name_icon_style "'name+icon'"
+
+# Default Value:
+set -g @tmux_window_name_icon_style "'name'"
+```
+
+### `@tmux_window_name_custom_icons`
+
+Customize icons for specific programs. \
+The value should be a JSON object mapping program names to their icons.
+
+```tmux.conf
+# Custom icons example
+set -g @tmux_window_name_custom_icons '{"python": "🐍", "custom_app": "📦"}'
+
+# Default Value:
+set -g @tmux_window_name_custom_icons '{}'
+```
+
+_**Note**_: Icons can be any Unicode characters, including emoji or Nerd Font icons. \
+If using Nerd Font icons, make sure your terminal supports them.
+
 ---
 
 ## Debug Configuration Options

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -70,7 +70,12 @@ def get_option(server: Server, option: str, default: Any) -> Any:
     if len(out) == 0:
         return default
 
-    return eval(out[0])
+    value = out[0]
+    # Handle string values
+    if isinstance(default, str):
+        return value
+    # Handle other types
+    return eval(value)
 
 
 def set_option(server: Server, option: str, val: str):
@@ -173,7 +178,7 @@ class Options:
     ignored_programs: List[str] = field(default_factory=lambda: [])
     max_name_len: int = 20
     use_tilde: bool = False
-    use_nerd_font_icons: bool = False
+    icon_style: str = 'name'  # Can be: 'name', 'icon', 'name+icon'
     substitute_sets: List[Tuple] = field(
         default_factory=lambda: [
             (r'.+ipython([32])', r'ipython\g<1>'),
@@ -273,10 +278,13 @@ def get_session_active_panes(session: Session) -> List[TmuxPane]:
 def rename_window(server: Server, window_id: str, window_name: str, max_name_len: int, options: Options):
     logging.debug(f'renaming window_id={window_id} to window_name={window_name}')
 
-    if options.use_nerd_font_icons:
+    if options.icon_style in ['icon', 'name+icon']:
         icon = get_program_icon(window_name)
         if icon:
-            window_name = f'{icon} {window_name}'
+            if options.icon_style == 'icon':
+                window_name = icon
+            elif options.icon_style == 'name+icon':
+                window_name = f'{icon} {window_name}'
             logging.debug(f'Added icon {icon} to window name. New name: {window_name}')
 
     window_name = window_name[:max_name_len]
@@ -392,10 +400,13 @@ def print_programs(server: Server, options: Options):
     for pane in panes_programs:
         if pane.program:
             program_name = substitute_name(pane.program, options.substitute_sets)
-            if options.use_nerd_font_icons:
+            if options.icon_style in ['icon', 'name+icon']:
                 icon = get_program_icon(program_name)
                 if icon:
-                    program_name = f'{icon} {program_name}'
+                    if options.icon_style == 'icon':
+                        program_name = icon
+                    elif options.icon_style == 'name+icon':
+                        program_name = f'{icon} {program_name}'
             print(f'{pane.program} -> {program_name}')
 
 

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -24,28 +24,29 @@ HOOK_INDEX = 8921
 # Mapping of program names to their nerd font icons
 PROGRAM_ICONS = {
     'nvim': '',  # nf-dev-vim
-    'vim': '',   # nf-dev-vim
-    'vi': '',    # nf-dev-vim
-    'git': '',   # nf-dev-git
-    'python': '', # nf-dev-python
-    'node': '',   # nf-dev-nodejs
-    'npm': '',    # nf-dev-nodejs
-    'yarn': '',   # nf-dev-nodejs
-    'docker': '', # nf-dev-docker
-    'kubectl': '', # nf-dev-kubernetes
-    'go': '',     # nf-dev-go
-    'rust': '',   # nf-dev-rust
+    'vim': '',  # nf-dev-vim
+    'vi': '',  # nf-dev-vim
+    'git': '',  # nf-dev-git
+    'python': '',  # nf-dev-python
+    'node': '',  # nf-dev-nodejs
+    'npm': '',  # nf-dev-nodejs
+    'yarn': '',  # nf-dev-nodejs
+    'docker': '',  # nf-dev-docker
+    'kubectl': '',  # nf-dev-kubernetes
+    'go': '',  # nf-dev-go
+    'rust': '',  # nf-dev-rust
     'cargo': '',  # nf-dev-rust
-    'php': '',    # nf-dev-php
-    'ruby': '',   # nf-dev-ruby
-    'java': '',   # nf-dev-java
-    'mvn': '',    # nf-dev-java
-    'gradle': '', # nf-dev-java
-    'bash': '',   # nf-dev-terminal
-    'zsh': '',    # nf-dev-terminal
-    'fish': '',   # nf-dev-terminal
-    'sh': '',     # nf-dev-terminal
+    'php': '',  # nf-dev-php
+    'ruby': '',  # nf-dev-ruby
+    'java': '',  # nf-dev-java
+    'mvn': '',  # nf-dev-java
+    'gradle': '',  # nf-dev-java
+    'bash': '',  # nf-dev-terminal
+    'zsh': '',  # nf-dev-terminal
+    'fish': '',  # nf-dev-terminal
+    'sh': '',  # nf-dev-terminal
 }
+
 
 def get_program_icon(program_name: str, options: 'Options') -> str:
     """Get the nerd font icon for a program name."""
@@ -54,15 +55,16 @@ def get_program_icon(program_name: str, options: 'Options') -> str:
     # If the name contains a colon, use the part before it
     if ':' in base_name:
         base_name = base_name.split(':')[0]
-    
+
     # First check custom icons, then fall back to built-in icons
     icon = options.custom_icons.get(base_name) or PROGRAM_ICONS.get(base_name, '')
-    
+
     # Decode Unicode escape sequences if present
     if icon.startswith('\\u'):
         icon = icon.encode('utf-8').decode('unicode-escape')
     logging.debug(f'Getting icon for program {program_name} (base_name: {base_name}) -> {icon!r}')
     return icon
+
 
 HOME_DIR = os.path.expanduser('~')
 USR_BIN_REMOVER = (r'^(/usr)?/bin/(.+)', r'\g<2>')
@@ -81,9 +83,10 @@ def get_option(server: Server, option: str, default: Any) -> Any:
     if isinstance(default, dict):
         try:
             import json
+
             return json.loads(value)
         except json.JSONDecodeError:
-            logging.warning(f"Failed to parse JSON for option {option}, using default")
+            logging.warning(f'Failed to parse JSON for option {option}, using default')
             return default
     # Handle other types
     return eval(value)

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -77,6 +77,14 @@ def get_option(server: Server, option: str, default: Any) -> Any:
     # Handle string values
     if isinstance(default, str):
         return value
+    # Handle dict values (for custom_icons)
+    if isinstance(default, dict):
+        try:
+            import json
+            return json.loads(value)
+        except json.JSONDecodeError:
+            logging.warning(f"Failed to parse JSON for option {option}, using default")
+            return default
     # Handle other types
     return eval(value)
 
@@ -408,7 +416,7 @@ def print_programs(server: Server, options: Options):
                 icon = get_program_icon(program_name, options)
                 if icon:
                     if options.icon_style == 'icon':
-                        program_name = icon
+                        program_name = f'{icon} '
                     elif options.icon_style == 'name+icon':
                         program_name = f'{icon} {program_name}'
             print(f'{pane.program} -> {program_name}')

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+import sys
+from dataclasses import dataclass
+from typing import Optional
+from unittest.mock import Mock, patch, call
+
+sys.path.append('scripts/')
+
+from rename_session_windows import Options, get_program_icon, rename_window, PROGRAM_ICONS
+
+
+@dataclass
+class FakeServer:
+    def __init__(self):
+        self.cmd = Mock()
+        self.cmd.return_value = self
+
+
+def test_get_program_icon_built_in():
+    """Test retrieving built-in program icons"""
+    options = Options()
+    assert get_program_icon('nvim', options) == PROGRAM_ICONS['nvim']  # vim icon
+    assert get_program_icon('python', options) == PROGRAM_ICONS['python']  # python icon
+    assert get_program_icon('nonexistent', options) == ''  # no icon
+
+
+def test_get_program_icon_custom():
+    """Test custom program icons override built-in ones"""
+    options = Options(
+        custom_icons={
+            'custom_app': '󰀄',
+            'nvim': '󰹻',  # override default vim icon
+        }
+    )
+    assert get_program_icon('custom_app', options) == '󰀄'
+    assert get_program_icon('nvim', options) == '󰹻'  # should use custom icon
+    assert get_program_icon('python', options) == PROGRAM_ICONS['python']  # should use built-in icon
+
+
+def test_get_program_icon_with_path():
+    """Test that program icons work with full paths"""
+    options = Options()
+    assert get_program_icon('/usr/bin/python', options) == PROGRAM_ICONS['python']
+    assert get_program_icon('/custom/path/nvim', options) == PROGRAM_ICONS['nvim']
+
+
+def test_get_program_icon_with_args():
+    """Test that program icons work with command arguments"""
+    options = Options()
+    assert get_program_icon('python script.py --arg', options) == PROGRAM_ICONS['python']
+    assert get_program_icon('nvim file.txt', options) == PROGRAM_ICONS['nvim']
+
+
+def test_rename_window_name_style():
+    """Test window renaming with 'name' style (default)"""
+    server = FakeServer()
+    options = Options(icon_style='name')
+    rename_window(server, '1', 'python', 20, options)
+    expected_calls = [
+        call('rename-window', '-t', '1', 'python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename-format', 'python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename', 'on'),
+    ]
+    assert server.cmd.call_args_list == expected_calls
+
+
+def test_rename_window_icon_style():
+    """Test window renaming with 'icon' style"""
+    server = FakeServer()
+    options = Options(icon_style='icon')
+    rename_window(server, '1', 'python', 20, options)
+    expected_calls = [
+        call('rename-window', '-t', '1', PROGRAM_ICONS['python']),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename-format', PROGRAM_ICONS['python']),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename', 'on'),
+    ]
+    assert server.cmd.call_args_list == expected_calls
+
+
+def test_rename_window_name_plus_icon_style():
+    """Test window renaming with 'name+icon' style"""
+    server = FakeServer()
+    options = Options(icon_style='name+icon')
+    rename_window(server, '1', 'python', 20, options)
+    expected_calls = [
+        call('rename-window', '-t', '1', f'{PROGRAM_ICONS["python"]} python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename-format', f'{PROGRAM_ICONS["python"]} python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename', 'on'),
+    ]
+    assert server.cmd.call_args_list == expected_calls
+
+
+def test_rename_window_custom_icon():
+    """Test window renaming with custom icon"""
+    server = FakeServer()
+    options = Options(icon_style='name+icon', custom_icons={'python': '🐍'})
+    rename_window(server, '1', 'python', 20, options)
+    expected_calls = [
+        call('rename-window', '-t', '1', '🐍 python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename-format', '🐍 python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename', 'on'),
+    ]
+    assert server.cmd.call_args_list == expected_calls
+
+
+def test_rename_window_max_length():
+    """Test that window names respect max_name_len"""
+    server = FakeServer()
+    options = Options(icon_style='name+icon', max_name_len=10)
+    rename_window(server, '1', 'python', 10, options)
+    expected_calls = [
+        call('rename-window', '-t', '1', f'{PROGRAM_ICONS["python"]} python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename-format', f'{PROGRAM_ICONS["python"]} python'),
+        call('set-option', '-wq', '-t', '1', 'automatic-rename', 'on'),
+    ]
+    assert server.cmd.call_args_list == expected_calls
+
+
+def test_get_program_icon_with_colon():
+    """Test that program icons work with program names containing colons"""
+    options = Options()
+    assert get_program_icon('python:3.9', options) == PROGRAM_ICONS['python']
+    assert get_program_icon('nvim:q', options) == PROGRAM_ICONS['nvim']
+
+
+def test_custom_icons_json_parsing():
+    """Test that custom icons can be parsed from JSON string"""
+    server = FakeServer()
+    server.cmd.return_value.stdout = ['{"python": "🐍", "custom": "📦"}']
+    options = Options.from_options(server)
+    assert get_program_icon('python', options) == '🐍'
+    assert get_program_icon('custom', options) == '📦'
+
+
+def test_invalid_custom_icons_json():
+    """Test handling of invalid JSON for custom icons"""
+    server = FakeServer()
+
+    # Use simple approach that doesn't require complicated patching
+    def custom_cmd(*args):
+        result = Mock()
+        option = args[2] if len(args) > 2 else ''
+
+        if option.endswith('custom_icons'):
+            result.stdout = ['{invalid json']  # Invalid JSON
+        else:
+            result.stdout = []  # Empty for all other options, will use defaults
+        return result
+
+    server.cmd.side_effect = custom_cmd
+
+    # Create options with default values except for custom_icons
+    options = Options.from_options(server)
+
+    # Should fall back to default (empty dict)
+    assert options.custom_icons == {}


### PR DESCRIPTION
Inspired by https://github.com/joshmedeski/tmux-nerd-font-window-name, this change allows users to show Nerd Font icons for their programs. The icons are fully customisable.

Example: 
<img width="731" alt="image" src="https://github.com/user-attachments/assets/95ac6e42-f25c-4313-8a45-03f86de4299f" />

