### PR TITLE
Show icon only (without program name) for dir_programs when icon is available

### DIFF
--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -388,7 +388,16 @@ def rename_windows(server: Server, options: Options):
             display_path = substitute_name(str(display_path), options.dir_substitute_sets)
             if p.program is not None:
                 p.program = substitute_name(p.program, options.substitute_sets)
-                display_path = f'{p.program}:{display_path}'
+
+                # Get icon for the program if available
+                icon = get_program_icon(p.program, options)
+
+                # If icon exists and icon_style includes icons, show icon + dir only
+                if icon and options.icon_style in [IconStyle.ICON, IconStyle.NAME_AND_ICON]:
+                    display_path = f'{icon}:{display_path}'
+                else:
+                    # No icon available or icon_style is NAME, show program name
+                    display_path = f'{p.program}:{display_path}'
 
             rename_window(server, str(p.info.window_id), str(display_path), options.max_name_len, options)
 


### PR DESCRIPTION
## Summary

This PR enhances the display of window names for programs in the `dir_programs` list by showing only the icon and directory path when an icon is available, rather than displaying both the program name and icon.

## Changes

When a program is in the `dir_programs` list and has an associated icon (either custom or default), the window name now displays:
- **Before**: `nvim:project-dir` or ` nvim:project-dir`  
- **After**: `:project-dir`

This provides a cleaner, more concise window name display while maintaining all the essential information.

## Behavior

This change only applies when:
1. The program is in the `dir_programs` list
2. An icon is defined for the program (custom or default)
3. `icon_style` is set to `'icon'` or `'name_and_icon'`

Programs without icons continue to display the program name as before, ensuring backward compatibility.

## Example Configuration

```tmux
set -g @tmux_window_name_dir_programs "['nvim', 'vim', 'vi', 'git', 'claude']"
set -g @tmux_window_name_icon_style "'name_and_icon'"
set -g @tmux_window_name_custom_icons '{"claude": "🤖", "nvim": ""}'
```

With this configuration:
- Running `nvim` in `/home/user/project` displays: `:project`
- Running `claude` in `/home/user/docs` displays: `🤖:docs`
- Running a program without an icon still shows: `program:directory`

## Benefits

- **Cleaner UI**: Reduces visual clutter in the tmux status bar
- **Better icon utilization**: Icons serve their purpose by replacing text, not just decorating it
- **Backward compatible**: Programs without icons still show the program name
- **Respects user settings**: Only applies when user has configured icon_style appropriately

## Testing

Tested with:
- Programs with default icons (nvim, vim, git)
- Programs with custom icons
- Programs without icons
- Different `icon_style` settings
- Multiple tmux sessions and windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)