### PR TITLE
Fix Fish Shell Zombie Processes

### DIFF
--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -331,7 +331,9 @@ def rename_window(server: Server, window_id: str, window_name: str, max_name_len
 def get_panes_programs(session: Session, options: Options) -> List[Pane]:
     session_active_panes = get_session_active_panes(session)
     try:
-        running_programs = subprocess.check_output(['ps', '-a', '-oppid,command']).splitlines()[1:]
+        output_bytes = subprocess.check_output(['ps', '-a', '-oppid,command'])
+        all_lines_bytes = output_bytes.splitlines()[1:]
+        running_programs = [line for line in all_lines_bytes if b'<defunct>' not in line]
         logging.debug(f'running_programs={running_programs}')
     # can occur if ps has empty output
     except subprocess.CalledProcessError:


### PR DESCRIPTION
When using the fish shell, the command `ps -a -oppid,command` returns something like:
```
   PPID COMMAND
 105421 tmux
 157581 [fish] <defunct>
 188548 [fish] <defunct>
 188548 ps -a -oppid,command>
 ```
Then, `[fish] <defunct>` is taken as a valid program, even when filtering out the fish shell with the @tmux_window_name_shells option.
So the result is the tmux windows always getting the name "[fish] \<defunct>"

All of this can be resolved by slightly changing the `get_panes_programs` function.
The running programs are filtered to remove all lines containing the word "defunct".