### PR TITLE
Fix dir_programs not matching programs with full paths

### DIFF
--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -309,7 +309,7 @@ def get_program_if_dir(program_line: str, dir_programs: List[str]) -> Optional[s
     program = program_line.split()
 
     for p in dir_programs:
-        if p == program[0]:
+        if p == program[0] or p == Path(program[0]).name:
             program[0] = p
             return ' '.join(program)
 


### PR DESCRIPTION
`get_program_if_dir` compared against the full path token from `ps` (e.g. `/Users/user/.asdf/shims/bun`), so programs managed by tools like asdf, nix, or homebrew shims never matched entries in `dir_programs`. Fix checks against `Path(program[0]).name` as a fallback.