### PR TITLE
Fix path disambiguation for windows with None vs program

### DIFF
--- a/scripts/path_utils.py
+++ b/scripts/path_utils.py
@@ -71,7 +71,7 @@ def get_exclusive_paths(panes: List[Pane]) -> List[Tuple[Pane, Path]]:
                 continue
 
             # If different programs dont change display path
-            if panes[x].program != panes[y].program:
+            if panes[x].program != panes[y].program and None not in [panes[x].program, panes[y].program]:
                 continue
 
             # If full path equals no need to find a display path


### PR DESCRIPTION
  When comparing two windows with the same directory basename but
  different full paths, where one window has program=None (shell) and
  the other has a program (e.g., vim), both windows would display the
  same ambiguous name. When the program is closed the windows would
  correctly show the expected disambiguated names.

  The issue occurred because the code skipped intersection checks when
  comparing windows with different programs:

```
  if panes[x].program != panes[y].program:
      continue
```

  This caused None != "vim" to skip collision detection, preventing
  proper path disambiguation. Both windows would show "app" instead of
  "path1/app" and "path2/app"..

  Before fix (no program running in both):
      `2:path1/app   3:path2/app`    <-- properly disambiguated
  Before fix (vim program running in one):
      `2:app         3:[?]app`        <-- unexpected collision (unstable name change)

  After fix (no program running in both):
      `2:path1/app   3:path2/app`    <-- properly disambiguated
  After fix (vim program running in one):
      `2:path1/app   3:[?]path2/app`  <-- properly disambiguated