### PR TITLE
Add ignore_program_diffs option for path disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,30 @@ set -g @tmux_window_name_custom_icons '{}'
 _**Note**_: Icons can be any Unicode characters, including emoji or Nerd Font icons. \
 If using Nerd Font icons, make sure your terminal supports them.
 
+### `@tmux_window_name_ignore_program_diffs`
+
+Controls whether to disambiguate paths when windows have different programs. \
+When enabled, windows with the same directory basename are always disambiguated, providing stable names regardless of program state.
+
+```tmux.conf
+# Always disambiguate paths, even when programs differ
+set -g @tmux_window_name_ignore_program_diffs "True"
+
+# Default Value:
+set -g @tmux_window_name_ignore_program_diffs "False"
+```
+
+**Use case:** \
+Without this option, window names can change based on program state. For example, a shell in `~/projects/app` and vim in `~/work/app` would both show `"app"` while vim runs, then change to `"projects/app"` and `"work/app"` after vim exits. Enabling this option ensures consistent disambiguation.
+
+**Example with `True`:**
+- Shell in `~/projects/app` → `projects/app`
+- Vim in `~/work/app` → `vim:work/app`
+
+**Example with `False` (default):**
+- Shell in `~/projects/app` → `app` (while vim is in other window)
+- Vim in `~/work/app` → `vim:app`
+
 ---
 
 ## Debug Configuration Options

--- a/scripts/path_utils.py
+++ b/scripts/path_utils.py
@@ -51,7 +51,7 @@ def get_uncommon_path(a: Path, b: Path) -> Tuple[Path, Path]:
     return Path(*a.parts[x:]), Path(*b.parts[x:])
 
 
-def get_exclusive_paths(panes: List[Pane]) -> List[Tuple[Pane, Path]]:
+def get_exclusive_paths(panes: List[Pane], ignore_program_diffs: bool) -> List[Tuple[Pane, Path]]:
     """Get exclusive path for each pane (better explaining in the README)
 
     Args:
@@ -72,7 +72,8 @@ def get_exclusive_paths(panes: List[Pane]) -> List[Tuple[Pane, Path]]:
 
             # If different programs dont change display path
             if panes[x].program != panes[y].program:
-                continue
+                if not ignore_program_diffs:
+                    continue
 
             # If full path equals no need to find a display path
             if exc_paths[x].full == exc_paths[y].full:

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -172,6 +172,7 @@ class Options:
     shells: List[str] = field(default_factory=lambda: ['bash', 'fish', 'sh', 'zsh'])
     dir_programs: List[str] = field(default_factory=lambda: ['nvim', 'vim', 'vi', 'git'])
     ignored_programs: List[str] = field(default_factory=lambda: [])
+    ignore_program_diffs: bool = False
     max_name_len: int = 20
     use_tilde: bool = False
     icon_style: IconStyle = IconStyle.NAME
@@ -382,7 +383,7 @@ def rename_windows(server: Server, options: Options):
             pane.program, _ = substitute_name(str(pane.program), options.substitute_sets, options, True)
             rename_window(server, str(pane.info.window_id), pane.program, options.max_name_len, options)
 
-        exclusive_paths = get_exclusive_paths(panes_with_dir)
+        exclusive_paths = get_exclusive_paths(panes_with_dir, options.ignore_program_diffs)
         logging.debug(
             f'get_exclusive_paths result, input: panes_with_dir={panes_with_dir}, output: exclusive_paths={exclusive_paths}'
         )

--- a/tests/test_exclusive_paths.py
+++ b/tests/test_exclusive_paths.py
@@ -2,6 +2,7 @@
 
 # I hate this but i don't want to make it a pip package, its a script.
 import sys
+import pytest
 from typing import List, Optional, Tuple
 from dataclasses import dataclass
 
@@ -9,6 +10,8 @@ sys.path.append('scripts/')
 
 from path_utils import get_exclusive_paths, Pane
 
+
+pytestmark = pytest.mark.parametrize("ignore_program_diffs", [True, False])
 
 @dataclass
 class FakePane:
@@ -19,37 +22,40 @@ def _fake_pane(path: str, program: Optional[str]):
     return Pane(FakePane(path), program)
 
 
-def _check(expected: List[Tuple[str, Optional[str], str]]):
+def _check(expected: List[Tuple[str, Optional[str], str]], ignore_program_diffs: bool):
     """check expected displayed paths
 
     Args:
         expected (List[Tuple[str, Optional[str], str]]): list of (full_path, program, expected_display)
+        ignore_program_diffs (bool): ignore_program_diffs flag value to pass along to get_exclusive_paths
     E.g:
         _check([
             ('a/dir', 'p1', 'dir'), # Program p1 in a/dir will display dir (will be formated to p1:dir)
             ('b/dir', None, 'b/dir'), # Shell in b/dir will display b/dir
             ('c/dir', None', 'c/dir'), # Shell in c/dir will display c/dir
-        ])
+        ], False)
     """
     panes = [_fake_pane(full, program) for full, program, _ in expected]
-    exclusive_panes = get_exclusive_paths(panes)
+    exclusive_panes = get_exclusive_paths(panes, ignore_program_diffs)
     for (full, _, expected_display), (_, display) in zip(expected, exclusive_panes):
         assert str(display) == expected_display
 
 
-def test_not_intersect():
+def test_not_intersect(ignore_program_diffs: bool):
     _check(
         [
             ('a/a_dir', None, 'a_dir'),
             ('b/b_dir', None, 'b_dir'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
     _check(
         [
             ('a', None, 'a'),
             ('b', None, 'b'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
     _check(
@@ -57,62 +63,50 @@ def test_not_intersect():
             ('a', None, 'a'),
             ('b', None, 'b'),
             ('c', None, 'c'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
 
-def test_basic_intersect():
+def test_basic_intersect(ignore_program_diffs: bool):
     _check(
         [
             ('a/dir', None, 'a/dir'),
             ('b/dir', None, 'b/dir'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
 
-def test_not_same_length():
+def test_not_same_length(ignore_program_diffs: bool):
     _check(
         [
             ('a/b/dir', None, 'a/b/dir'),
             ('b/dir', None, 'b/dir'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
 
-def test_reacurring_dir():
+def test_reacurring_dir(ignore_program_diffs: bool):
     _check(
         [
             ('a/dir', None, 'a/dir'),
             ('b/dir', None, 'b/dir'),
             ('c/dir', None, 'c/dir'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
 
-def test_same_path_twice_dir():
+def test_same_path_twice_dir(ignore_program_diffs: bool):
     _check(
         [
             ('a/dir', None, 'a/dir'),
             ('a/dir', None, 'a/dir'),
             ('b/dir', None, 'b/dir'),
-        ]
-    )
-
-    _check(
-        [
-            ('a/dir', None, 'a/dir'),
-            ('b/dir', None, 'b/dir'),
-            ('a/dir', None, 'a/dir'),
-        ]
-    )
-
-    _check(
-        [
-            ('a/dir', None, 'a/dir'),
-            ('b/dir', None, 'b/dir'),
-            ('b/dir', None, 'b/dir'),
-            ('a/dir', None, 'a/dir'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
     _check(
@@ -120,8 +114,28 @@ def test_same_path_twice_dir():
             ('a/dir', None, 'a/dir'),
             ('b/dir', None, 'b/dir'),
             ('a/dir', None, 'a/dir'),
+        ],
+        ignore_program_diffs
+    )
+
+    _check(
+        [
+            ('a/dir', None, 'a/dir'),
             ('b/dir', None, 'b/dir'),
-        ]
+            ('b/dir', None, 'b/dir'),
+            ('a/dir', None, 'a/dir'),
+        ],
+        ignore_program_diffs
+    )
+
+    _check(
+        [
+            ('a/dir', None, 'a/dir'),
+            ('b/dir', None, 'b/dir'),
+            ('a/dir', None, 'a/dir'),
+            ('b/dir', None, 'b/dir'),
+        ],
+        ignore_program_diffs
     )
 
     _check(
@@ -132,17 +146,19 @@ def test_same_path_twice_dir():
             ('a/dir', None, 'a/dir'),
             ('b/dir', None, 'b/dir'),
             ('c/dir', None, 'c/dir'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
 
-def test_mixed_basic():
+def test_mixed_basic(ignore_program_diffs: bool):
     _check(
         [
             ('a/dir', None, 'a/dir'),
             ('b/dir', None, 'b/dir'),
             ('c/c_dir', None, 'c_dir'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
     _check(
@@ -150,63 +166,71 @@ def test_mixed_basic():
             ('a/b/c/d', None, 'a/b/c/d'),
             ('b/c/d', None, 'b/c/d'),
             ('dirrr', None, 'dirrr'),
-        ]
+        ],
+        ignore_program_diffs
     )
 
 
-def test_program_basic():
+def test_program_basic(ignore_program_diffs: bool):
     _check(
         [
-            ('a/dir', 'p1', 'dir'),
-            ('b/dir', None, 'dir'),
-        ]
-    )
-
-    _check(
-        [
-            ('a/dir', 'p1', 'dir'),
-            ('b/dir', 'p2', 'dir'),
-        ]
+            ('a/dir', 'p1', 'a/dir' if ignore_program_diffs else 'dir'),
+            ('b/dir', None, 'b/dir' if ignore_program_diffs else 'dir'),
+        ],
+        ignore_program_diffs
     )
 
     _check(
         [
-            ('a/dir', 'p1', 'a/dir'),
-            ('b/dir', 'p1', 'b/dir'),
-        ]
-    )
-
-    _check(
-        [
-            ('a/dir', 'p1', 'dir'),
-            ('b/dir', 'p2', 'dir'),
-        ]
-    )
-
-
-def test_program_mixed():
-    _check(
-        [
-            ('a/dir', 'p1', 'dir'),
-            ('b/dir', None, 'dir'),
-            ('c/dir', 'p2', 'dir'),
-        ]
-    )
-
-    _check(
-        [
-            ('a/dir', 'p1', 'dir'),
-            ('b/dir', None, 'dir'),
-            ('a/dir', 'p1', 'dir'),
-            ('c/dir', 'p2', 'dir'),
-        ]
+            ('a/dir', 'p1', 'a/dir' if ignore_program_diffs else 'dir'),
+            ('b/dir', 'p2', 'b/dir' if ignore_program_diffs else 'dir'),
+        ],
+        ignore_program_diffs
     )
 
     _check(
         [
             ('a/dir', 'p1', 'a/dir'),
             ('b/dir', 'p1', 'b/dir'),
+        ],
+        ignore_program_diffs
+    )
+
+    _check(
+        [
+            ('a/dir', 'p1', 'a/dir' if ignore_program_diffs else 'dir'),
+            ('b/dir', 'p2', 'b/dir' if ignore_program_diffs else 'dir'),
+        ],
+        ignore_program_diffs
+    )
+
+
+def test_program_mixed(ignore_program_diffs: bool):
+    _check(
+        [
+            ('a/dir', 'p1', 'a/dir' if ignore_program_diffs else 'dir'),
+            ('b/dir', None, 'b/dir' if ignore_program_diffs else 'dir'),
+            ('c/dir', 'p2', 'c/dir' if ignore_program_diffs else 'dir'),
+        ],
+        ignore_program_diffs
+    )
+
+    _check(
+        [
+            ('a/dir', 'p1', 'a/dir' if ignore_program_diffs else 'dir'),
+            ('b/dir', None, 'b/dir' if ignore_program_diffs else 'dir'),
+            ('a/dir', 'p1', 'a/dir' if ignore_program_diffs else 'dir'),
+            ('c/dir', 'p2', 'c/dir' if ignore_program_diffs else 'dir'),
+        ],
+        ignore_program_diffs
+    )
+
+    _check(
+        [
             ('a/dir', 'p1', 'a/dir'),
-            ('c/dir', 'p2', 'dir'),
-        ]
+            ('b/dir', 'p1', 'b/dir'),
+            ('a/dir', 'p1', 'a/dir'),
+            ('c/dir', 'p2', 'c/dir' if ignore_program_diffs else 'dir'),
+        ],
+        ignore_program_diffs
     )


### PR DESCRIPTION
Add @tmux_window_name_ignore_program_diffs option (default: False) that controls whether windows with different programs should be disambiguated by path.

When enabled (True), windows with the same directory basename are always disambiguated, even when running different programs. This provides stable window names that don't change based on program state.

For example, without this option, a shell (program=None) in ~/dir1/app and vim in ~/dir2/app would both display "app" while vim is running, then switch to "dir1/app" and "dir2/app" after vim exits. With the option enabled, they always show "dir1/app" and "dir2/app".