### PR TITLE
fix: match dir_programs against command arguments for interpreter-launched programs

### DIFF
--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -309,7 +309,7 @@ def get_program_if_dir(program_line: str, dir_programs: List[str]) -> Optional[s
     program = program_line.split()
 
     for p in dir_programs:
-        if p == program[0]:
+        if p == program[0] or p == Path(program[0]).name:
             program[0] = p
             return ' '.join(program)
 

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -229,10 +229,12 @@ def get_program_icon(program_name: str, options: Options) -> str:
     logging.debug(f'Getting icon for program {program_name} (base_name: {base_name}) -> {icon!r}')
     return icon
 
+
 @dataclass
 class StyleResult:
     icon_set: bool = False
     only_icon: bool = False
+
 
 def apply_icon_if_in_style(program_name: str, options: Options) -> Tuple[str, StyleResult]:
     if options.icon_style in [IconStyle.ICON, IconStyle.NAME_AND_ICON, IconStyle.DIR_AND_ICON]:
@@ -312,6 +314,9 @@ def get_program_if_dir(program_line: str, dir_programs: List[str]) -> Optional[s
         if p == program[0] or p == Path(program[0]).name:
             program[0] = p
             return ' '.join(program)
+        for word in program[1:]:
+            if word == p or word.endswith('/' + p):
+                return p
 
     return None
 
@@ -420,7 +425,10 @@ def get_current_session(server: Server) -> Session:
     session_id = server.cmd('display-message', '-p', '#{session_id}').stdout[0]
     return Session(server, session_id=session_id)
 
-def substitute_name(name: str, substitute_sets: List[Tuple], options: Options, apply_icon: bool) -> Tuple[str, StyleResult]:
+
+def substitute_name(
+    name: str, substitute_sets: List[Tuple], options: Options, apply_icon: bool
+) -> Tuple[str, StyleResult]:
     logging.debug(f'substituting {name}')
     for pattern, replacement in substitute_sets:
         name = re.sub(pattern, replacement, name)

--- a/tests/test_get_program_if_dir.py
+++ b/tests/test_get_program_if_dir.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.path.append('scripts/')
+
+from rename_session_windows import get_program_if_dir
+
+
+def test_exact_match():
+    assert get_program_if_dir('nvim', ['nvim', 'vim']) == 'nvim'
+
+
+def test_exact_match_with_args():
+    assert get_program_if_dir('git diff', ['git', 'nvim']) == 'git diff'
+
+
+def test_no_match():
+    assert get_program_if_dir('htop', ['nvim', 'git']) is None
+
+
+def test_no_match_empty_dir_programs():
+    assert get_program_if_dir('nvim', []) is None
+
+
+def test_interpreter_launched_exact_arg():
+    assert get_program_if_dir('/usr/bin/node /usr/bin/lazygit', ['lazygit']) == 'lazygit'
+
+
+def test_interpreter_launched_path_arg():
+    assert get_program_if_dir('/home/user/.asdf/shims/node /home/user/.bun/bin/some-cli', ['some-cli']) == 'some-cli'
+
+
+def test_interpreter_launched_no_match():
+    assert get_program_if_dir('/usr/bin/node /usr/bin/something', ['lazygit']) is None


### PR DESCRIPTION
## Summary

Complements #61 by also matching `dir_programs` against command arguments, not just the first word.

## Problem

#61 fixes the case where the first word is a full path (e.g. `/home/user/.asdf/shims/bun` → matches `bun` via basename).

However, programs launched via interpreters appear in `ps` as:

```
/home/user/.asdf/shims/node /home/user/.bun/bin/some-cli
```

Here the first word is the interpreter (`node`), and the actual program (`some-cli`) is an argument. Neither the original exact match nor #61's basename check catches this case.

## Solution

After checking the first word (with #61's basename fallback), also iterate over remaining arguments and match against `dir_programs` — both exact name and path suffix (`word.endswith('/' + p)`).

**Note:** This PR includes both fixes (basename + interpreter args). If #61 is merged first, only the argument-checking lines and tests will remain as the diff.

## Testing

Added `tests/test_get_program_if_dir.py` with 7 tests covering exact match, no match, interpreter-launched exact arg, interpreter-launched path arg, and no false positives.

All 30 tests pass.