### PR TITLE
feat: add uv / PEP 723 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,32 @@ vim.api.nvim_create_autocmd({ 'VimEnter', 'VimLeave' }, {
 })
 ```
 
+Or via `uv run --script` (resolves `libtmux` from PEP 723 metadata, no system install needed):
+```lua
+local loop = vim.uv
+
+vim.api.nvim_create_autocmd({ 'VimEnter', 'VimLeave' }, {
+	callback = function()
+		if vim.env.TMUX_PLUGIN_MANAGER_PATH then
+			local script = vim.env.TMUX_PLUGIN_MANAGER_PATH .. '/tmux-window-name/scripts/rename_session_windows.py'
+			loop.spawn('uv', { args = { 'run', '--script', script } })
+		end
+	end,
+})
+```
+
 ### Vim Script autocmd example 
 ```vim
 " update the script path based on your setup
 if !empty($TMUX) && has('job')
   autocmd VimEnter,VimLeave * call job_start(expand('$HOME/.config/tmux/plugins/tmux-window-name/scripts/rename_session_windows.py'))
+endif
+```
+
+Or via `uv run --script`:
+```vim
+if !empty($TMUX) && has('job')
+  autocmd VimEnter,VimLeave * call job_start('uv run --script ' . expand('$HOME/.config/tmux/plugins/tmux-window-name/scripts/rename_session_windows.py'))
 endif
 ```
 
@@ -101,6 +122,15 @@ By default `tmux-window-name` hooks `after-select-window` which trigged when swi
 ```bash
 tmux-window-name() {
 	($TMUX_PLUGIN_MANAGER_PATH/tmux-window-name/scripts/rename_session_windows.py &)
+}
+
+add-zsh-hook chpwd tmux-window-name
+```
+
+Or via `uv run --script`:
+```bash
+tmux-window-name() {
+	(uv run --script $TMUX_PLUGIN_MANAGER_PATH/tmux-window-name/scripts/rename_session_windows.py &)
 }
 
 add-zsh-hook chpwd tmux-window-name

--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ To make the shortest path as possible the plugin finds the shortest not common p
 
 ## Installation
 
+### Recommended: install [uv](https://docs.astral.sh/uv/)
+
+If `uv` is on your `PATH`, the plugin auto-detects it and runs the script via `uv run --script`. `libtmux` is resolved from inline script metadata; the steps below for `pip install libtmux` and `dataclasses` are **not needed** in this case.
+
+Install uv:
+```sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+If `uv` is not present, the plugin falls back to `python3` and requires `libtmux` to be installed manually — see the next section.
+
+---
+
 ### Install libtmux (must)
 _**Note**_: Make sure you are using the `user` python and not `sudo` python or `virutalenv` python!
 

--- a/scripts/rename_session_windows.py
+++ b/scripts/rename_session_windows.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.7"
+# dependencies = [
+#     "libtmux",
+# ]
+# ///
 
 import logging
 import logging.config
@@ -132,11 +138,13 @@ def enable_user_rename_hook(server: Server):
         Indicator if we should rename the window or not
     """
     current_file = Path(__file__).absolute()
+    launcher = os.environ.get('TMUX_WINDOW_NAME_LAUNCHER', '').strip()
+    invocation = f'{launcher} {current_file}' if launcher else str(current_file)
     server.cmd(
         'set-hook',
         '-g',
         f'after-rename-window[{HOOK_INDEX}]',
-        f'if-shell "[ #{{n:window_name}} -gt 0 ]" "set -w @tmux_window_name_enabled 0" "set -w @tmux_window_name_enabled 1; run-shell "{current_file}"',
+        f'if-shell "[ #{{n:window_name}} -gt 0 ]" "set -w @tmux_window_name_enabled 0" "set -w @tmux_window_name_enabled 1; run-shell \\"{invocation}\\""',
     )
 
 

--- a/tmux_window_name.tmux
+++ b/tmux_window_name.tmux
@@ -2,22 +2,28 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-LIBTMUX_AVAILABLE=$(python -c "import importlib.util; print(importlib.util.find_spec('libtmux') is not None)" 2>/dev/null)
-if [ "$LIBTMUX_AVAILABLE" = "False" ]; then
-    tmux display "ERROR: tmux-window-name - Python dependency libtmux not found (Check the README)"
-    exit 0
+if command -v uv >/dev/null 2>&1; then
+    LAUNCHER="uv run --script"
+else
+    LAUNCHER="python3"
+    LIBTMUX_AVAILABLE=$(python3 -c "import importlib.util; print(importlib.util.find_spec('libtmux') is not None)" 2>/dev/null)
+    if [ "$LIBTMUX_AVAILABLE" = "False" ]; then
+        tmux display "ERROR: tmux-window-name - Python dependency libtmux not found (Check the README)"
+        exit 0
+    fi
 fi
+export TMUX_WINDOW_NAME_LAUNCHER="$LAUNCHER"
 
 tmux set -g automatic-rename on # Set automatic-rename on to make #{automatic-rename} be on when a new window is been open without a name
 tmux set-hook -g 'after-new-window[8921]' 'set -wF @tmux_window_name_enabled \#\{automatic-rename\} ; set -w automatic-rename off'
-tmux set-hook -g 'after-select-window[8921]' "run-shell -b ""$CURRENT_DIR""/scripts/rename_session_windows.py"
+tmux set-hook -g 'after-select-window[8921]' "run-shell -b \"$LAUNCHER $CURRENT_DIR/scripts/rename_session_windows.py\""
 
 ############################################################################################
 ### Hacks for preserving users custom window names, read more at enable_user_rename_hook ###
 ############################################################################################
 
-"$CURRENT_DIR"/scripts/rename_session_windows.py --enable_rename_hook
+$LAUNCHER "$CURRENT_DIR"/scripts/rename_session_windows.py --enable_rename_hook
 
 # Disabling rename hooks when tmux-ressurect restores the sessions
-tmux set -g @resurrect-hook-pre-restore-all ""$CURRENT_DIR"/scripts/rename_session_windows.py --disable_rename_hook"
-tmux set -g @resurrect-hook-post-restore-all ""$CURRENT_DIR"/scripts/rename_session_windows.py --post_restore"
+tmux set -g @resurrect-hook-pre-restore-all "$LAUNCHER $CURRENT_DIR/scripts/rename_session_windows.py --disable_rename_hook"
+tmux set -g @resurrect-hook-post-restore-all "$LAUNCHER $CURRENT_DIR/scripts/rename_session_windows.py --post_restore"


### PR DESCRIPTION
  Adds `uv` / [PEP 723 inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/) support so users can run the plugin without manually installing `libtmux`. Existing
  `python3` + system `libtmux` path is unchanged.

  ## What changes

  - **`scripts/rename_session_windows.py`** — PEP 723 metadata block added after the shebang. The block is a Python comment so the file still runs as-is under `python3`; `uv` parses it and provisions a cached venv
   with `libtmux`.
  - **`tmux_window_name.tmux`** — auto-detects `uv` on `PATH`. If found, all script invocations route through `uv run --script`. Otherwise the original `python3` + libtmux import check runs unchanged. Zero config;
   existing users see no behavior change.
  - **`enable_user_rename_hook`** — the `after-rename-window` hook value previously hardcoded the bare script path and relied on the python3 shebang. That bypassed the launcher under the uv path. Now it reads
  `TMUX_WINDOW_NAME_LAUNCHER` (exported from `.tmux`) and prefixes the hook's `run-shell` command. Pre-existing unbalanced quotes around the run-shell argument are also fixed (they broke once the path string
  contained spaces from the `uv run --script` prefix).
  - **`README.md`** —
    - New `### Recommended: install uv` section above the libtmux install instructions, explaining `pip install` is not needed when uv is present.
    - The nvim Lua autocmd, vim `job_start`, and zsh `chpwd` snippets gain parallel `uv run --script` variants below the originals (originals kept as-is).

  ## How to verify

  ```sh
  # uv path — works without system libtmux
  uv run --script scripts/rename_session_windows.py --help

  # python3 path — works with system libtmux installed (existing behaviour)
  python3 scripts/rename_session_windows.py --help

  Manual smoke (4 quadrants):

  ┌────────────┬────────────────┬──────────────────────────────────────────────┐
  │ uv on PATH │ system libtmux │                   Expected                   │
  ├────────────┼────────────────┼──────────────────────────────────────────────┤
  │ yes        │ no             │ hooks register with uv run --script prefix   │
  ├────────────┼────────────────┼──────────────────────────────────────────────┤
  │ yes        │ yes            │ uv branch wins (prefix in hook value)        │
  ├────────────┼────────────────┼──────────────────────────────────────────────┤
  │ no         │ yes            │ original python3 branch, no behaviour change │
  ├────────────┼────────────────┼──────────────────────────────────────────────┤
  │ no         │ no             │ existing tmux error display, plugin disabled │
  └────────────┴────────────────┴──────────────────────────────────────────────┘

  Verify hook strings:
  tmux show-hooks -g | grep 8921

  Notes

  - requires-python = ">=3.7" matches the existing pyproject.toml ruff target-version.
  - No automated test changes. Existing pytest suite continues to use system-installed libtmux.
  - path_utils.py is unchanged — PEP 723 metadata only goes on the entrypoint script.

